### PR TITLE
Do not call speaker.{Resume(),Suspend()} in sound.Play* anymore

### DIFF
--- a/internal/sound/sound_disabled.go
+++ b/internal/sound/sound_disabled.go
@@ -6,14 +6,22 @@ package sound
 const Enabled bool = false
 const panicMsg string = "Sound disabled in this build"
 
-func PlaySendNotification(callback func()) {
+func Resume() {
 	panic(panicMsg)
 }
 
-func PlayCancelNotification(callback func()) {
+func Suspend() {
 	panic(panicMsg)
 }
 
-func Init() error {
+func PlaySendNotification(func()) {
+	panic(panicMsg)
+}
+
+func PlayCancelNotification(func()) {
+	panic(panicMsg)
+}
+
+func Init(bool) error {
 	panic(panicMsg)
 }

--- a/internal/sound/sound_test.go
+++ b/internal/sound/sound_test.go
@@ -13,7 +13,7 @@ func TestPlaySendAndCancelNotification(t *testing.T) {
 		t.Skip("Skipping testing in CI environment")
 	}
 
-	err := Init()
+	err := Init(false)
 	if err != nil {
 		t.Fatalf("Error while initialising sound: %v\n", err)
 	}

--- a/main.go
+++ b/main.go
@@ -21,7 +21,7 @@ func main() {
 	settings = core.ParseFlags(os.Args[0], os.Args[1:], version, optional)
 
 	if optional.Sound {
-		err := sound.Init()
+		err := sound.Init(!settings.Sound)
 		if err != nil {
 			log.Printf("Error while initialising sound: %v.\n", err)
 			log.Println("Disabling sound...")

--- a/systray.go
+++ b/systray.go
@@ -11,6 +11,7 @@ import (
 	"fyne.io/systray"
 
 	"github.com/thiagokokada/twenty-twenty-twenty/internal/core"
+	"github.com/thiagokokada/twenty-twenty-twenty/internal/sound"
 )
 
 const systrayEnabled bool = true
@@ -94,10 +95,12 @@ func onReady() {
 			}
 		case <-mSound.ClickedCh:
 			if mSound.Checked() {
+				sound.Suspend()
 				settings.Sound = false
 
 				withMutex(&mu, func() { mSound.Uncheck() })
 			} else {
+				sound.Resume()
 				settings.Sound = true
 
 				withMutex(&mu, func() { mSound.Check() })


### PR DESCRIPTION
This is causing more issues than it needed to, and the CPU usage while it is unfortunate it is not that bad.

We will still call speaker.Suspend() when the sound is disabled and speaker.Resume() when the sound is re-enabled. This results in 0% CPU usage when this feature is not used, and doesn't need to bring back the complicated initialisation code we had before.